### PR TITLE
remove windows as testing platform

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest]
         php: [8.2, 8.1]
         laravel: [10.*]
         stability: [prefer-lowest, prefer-stable]


### PR DESCRIPTION
This PR removes windows as a testing platform for our github actions because it has caused a lot of issues and is incompatible with a lot of stuff.