### PR TITLE
add MemoryUsageCheck, Linux only for now.

### DIFF
--- a/src/Checks/MemoryUsageCheck.php
+++ b/src/Checks/MemoryUsageCheck.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Vormkracht10\LaravelOK\Checks;
+
+use Vormkracht10\LaravelOK\Checks\Base\Check;
+use Vormkracht10\LaravelOK\Checks\Base\Result;
+
+class MemoryUsageCheck extends Check
+{
+    // Runs on Linux only.
+
+    protected int $limit = 90;
+
+    public function threshold(int $percentage): static
+    {
+        $this->limit = $percentage;
+
+        return $this;
+    }
+
+    public function getSystemMemInfo()
+    {
+        $data = explode("\n", trim(file_get_contents("/proc/meminfo")));
+        $memInfo = [];
+
+        foreach ($data as $line) {
+            [$key, $val] = explode(":", $line);
+            $memInfo[$key] = explode(' ', trim($val), 2)[0];
+        }
+
+        return $memInfo;
+    }
+
+    public function run(): Result
+    {
+        $result = Result::new();
+
+        $data = $this->getSystemMemInfo();
+
+        $usedPercentage = round(100 - (($data['MemAvailable'] / $data['MemTotal']) * 100), 2);
+
+        if ($usedPercentage > $this->limit) {
+            return $result->failed("memory usage is at {$usedPercentage}%, limit is configured to {$this->limit}%");
+        }
+
+        return $result->ok("memory usage is at {$usedPercentage}");
+    }
+}

--- a/src/Checks/MemoryUsageCheck.php
+++ b/src/Checks/MemoryUsageCheck.php
@@ -20,11 +20,11 @@ class MemoryUsageCheck extends Check
 
     public function getSystemMemInfo()
     {
-        $data = explode("\n", trim(file_get_contents("/proc/meminfo")));
+        $data = explode("\n", trim(file_get_contents('/proc/meminfo')));
         $memInfo = [];
 
         foreach ($data as $line) {
-            [$key, $val] = explode(":", $line);
+            [$key, $val] = explode(':', $line);
             $memInfo[$key] = explode(' ', trim($val), 2)[0];
         }
 


### PR DESCRIPTION
This PR adds a MemoryUsageCheck, it works with percentages instead of raw numbers, it can be configured like this.
```php
OK::checks([
    MemoryUsageCheck::config()
        ->threshold(90),
]);
```
Setting the threshold to 90 will fail the check when your memory usage (according to `/proc/meminfo`) is *over* 90%. The default threshold is 90.