### PR TITLE
add QueueCheck

### DIFF
--- a/src/Checks/QueueCheck.php
+++ b/src/Checks/QueueCheck.php
@@ -16,14 +16,14 @@ class QueueCheck extends Check
 
     protected array $onQueues = [];
 
-    protected function failAfter(int $seconds): static
+    public function failAfter(int $seconds): static
     {
         $this->maxRuntime = $seconds;
 
         return $this;
     }
 
-    protected function cacheDriver(string $name): static
+    public function cacheDriver(string $name): static
     {
         $this->cacheDriver = $name;
 

--- a/src/Checks/QueueCheck.php
+++ b/src/Checks/QueueCheck.php
@@ -52,6 +52,7 @@ class QueueCheck extends Check
 
             if ($pending) {
                 sleep(1);
+
                 continue;
             }
 
@@ -64,7 +65,7 @@ class QueueCheck extends Check
 
         $failed = array_diff($this->onQueues, $this->ranQueues());
 
-        return $result->failed('some queues didn\'t run: ' . implode(', ', $failed));
+        return $result->failed('some queues didn\'t run: '.implode(', ', $failed));
     }
 
     public function getCacheDriver(): string
@@ -76,7 +77,7 @@ class QueueCheck extends Check
     {
         return array_filter(
             $this->onQueues,
-            fn($queue) => Cache::driver($this->getCacheDriver())->get("{$this->key}:{$queue}", false) == true,
+            fn ($queue) => Cache::driver($this->getCacheDriver())->get("{$this->key}:{$queue}", false) == true,
         );
     }
 

--- a/src/Checks/QueueCheck.php
+++ b/src/Checks/QueueCheck.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Vormkracht10\LaravelOK\Checks;
+
+use Illuminate\Support\Facades\Cache;
+use Vormkracht10\LaravelOK\Checks\Base\Check;
+use Vormkracht10\LaravelOK\Checks\Base\Result;
+
+class QueueCheck extends Check
+{
+    protected string $key = 'laravel-ok:queue-check:key';
+
+    protected int $maxRuntime = 10;
+
+    protected ?string $cacheDriver;
+
+    protected array $onQueues = [];
+
+    protected function failAfter(int $seconds): static
+    {
+        $this->maxRuntime = $seconds;
+
+        return $this;
+    }
+
+    protected function cacheDriver(string $name): static
+    {
+        $this->cacheDriver = $name;
+
+        return $this;
+    }
+
+    public function onQueues(array $queues): static
+    {
+        $this->onQueues = $queues;
+
+        return $this;
+    }
+
+    public function run(): Result
+    {
+        $result = Result::new();
+
+        foreach ($this->onQueues as $queue) {
+            $this->runQueue($queue);
+        }
+
+        $max = now()->addSeconds($this->maxRuntime);
+
+        do {
+            $pending = array_diff($this->onQueues, $this->ranQueues());
+
+            if ($pending) {
+                sleep(1);
+                continue;
+            }
+
+            foreach ($this->onQueues as $queue) {
+                Cache::driver($this->getCacheDriver())->forget("{$this->key}:{$queue}");
+            }
+
+            return $result->ok('all queues ran');
+        } while (now() < $max);
+
+        $failed = array_diff($this->onQueues, $this->ranQueues());
+
+        return $result->failed('some queues didn\'t run: ' . implode(', ', $failed));
+    }
+
+    public function getCacheDriver(): string
+    {
+        return $this->cacheDriver ?? config('cache.default', 'array');
+    }
+
+    public function ranQueues(): array
+    {
+        return array_filter(
+            $this->onQueues,
+            fn($queue) => Cache::driver($this->getCacheDriver())->get("{$this->key}:{$queue}", false) == true,
+        );
+    }
+
+    public function runQueue(string $name): void
+    {
+        $key = "{$this->key}:{$name}";
+        $driver = $this->getCacheDriver();
+        $ttl = $this->maxRuntime;
+
+        dispatch(function () use ($key, $driver, $ttl) {
+            Cache::driver($driver)->put($key, true, $ttl);
+        })->onQueue($name);
+    }
+}

--- a/src/Checks/QueueCheck.php
+++ b/src/Checks/QueueCheck.php
@@ -64,6 +64,7 @@ class QueueCheck extends Check
 
             if (is_null($lastHeartbeat)) {
                 $failed[] = $queue;
+
                 continue;
             }
 
@@ -77,7 +78,7 @@ class QueueCheck extends Check
         }
 
         if (! empty($failed)) {
-            return $result->failed('There were issues with some queues: ' . implode(', ', $failed));
+            return $result->failed('There were issues with some queues: '.implode(', ', $failed));
         }
 
         return $result->ok('All queues are doing fine.');

--- a/src/Commands/DispatchQueueCheckJobsCommand.php
+++ b/src/Commands/DispatchQueueCheckJobsCommand.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Vormkracht10\LaravelOK\Commands;
+
+use Illuminate\Console\Command;
+use Vormkracht10\LaravelOK\Checks\Base\Check;
+use Vormkracht10\LaravelOK\Checks\QueueCheck;
+use Vormkracht10\LaravelOK\Facades\OK;
+use Vormkracht10\LaravelOK\Jobs\QueueHeartbeatJob;
+
+class DispatchQueueCheckJobsCommand extends Command
+{
+    protected $signature = 'ok:queue-check-jobs';
+
+    public function handle(): int
+    {
+        $checks = OK::configuredChecks()->filter(fn (Check $check) => $check instanceof QueueCheck);
+
+        /**
+         * @var QueueCheck $check
+         */
+        foreach ($checks as $check) {
+            foreach ($check->getQueues() as $queue) {
+                QueueHeartbeatJob::dispatch($check)->onQueue($queue);
+            }
+        }
+
+        return static::SUCCESS;
+    }
+}

--- a/src/Jobs/QueueHeartbeatJob.php
+++ b/src/Jobs/QueueHeartbeatJob.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Vormkracht10\LaravelOK\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Support\Facades\Cache;
+use Vormkracht10\LaravelOK\Checks\QueueCheck;
+
+class QueueHeartbeatJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable;
+
+    protected QueueCheck $check;
+
+    public function __construct(QueueCheck $check)
+    {
+        $this->check = $check;
+    }
+
+    public function handle(): void
+    {
+        $key = $this->check->getCacheKey($this->queue);
+
+        Cache::driver($this->check->getCacheDriver())
+            ->set($key, now()->timestamp);
+    }
+}

--- a/src/LaravelOKServiceProvider.php
+++ b/src/LaravelOKServiceProvider.php
@@ -5,6 +5,7 @@ namespace Vormkracht10\LaravelOK;
 use Spatie\LaravelPackageTools\Commands\InstallCommand;
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
+use Vormkracht10\LaravelOK\Commands\DispatchQueueCheckJobsCommand;
 use Vormkracht10\LaravelOK\Commands\RunChecksCommand;
 use Vormkracht10\LaravelOK\Events\CheckFailed;
 use Vormkracht10\LaravelOK\Listeners\SendCheckFailedNotification;
@@ -19,6 +20,7 @@ class LaravelOKServiceProvider extends PackageServiceProvider
             // ->hasMigration('create_laravel_ok_table')
             ->hasCommands(
                 RunChecksCommand::class,
+                DispatchQueueCheckJobsCommand::class,
             )
             ->hasViews('ok')
             ->hasInstallCommand(function (InstallCommand $command) {


### PR DESCRIPTION
This PR adds the `QueueCheck`, this will dispatch a job for each configured Queue and check if they have been run.
It uses the cache to check if jobs have been run on their queue.

It can be configured like this
```php
OK::checks([
    QueueCheck::config()
        ->queues([
            'default',
        ])
        ->maxHeartbeatDelay(1), // minutes
]);
```