### PR TITLE
add StorageCheck

### DIFF
--- a/src/Checks/StorageCheck.php
+++ b/src/Checks/StorageCheck.php
@@ -3,7 +3,6 @@
 namespace Vormkracht10\LaravelOK\Checks;
 
 use Illuminate\Contracts\Filesystem\Filesystem as FilesystemContract;
-use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Storage;
 use Vormkracht10\LaravelOK\Checks\Base\Check;
@@ -15,7 +14,7 @@ class StorageCheck extends Check
 
     protected array $disks = [];
 
-    public function path(?string $value = null): static
+    public function path(string $value = null): static
     {
         $this->path = $value;
 
@@ -53,10 +52,14 @@ class StorageCheck extends Check
         foreach ($this->disks as $disk) {
             $disk = Storage::disk($disk);
 
-            if (! $this->checkDisk($disk, $this->path)) $failed[] = $disk;
+            if (! $this->checkDisk($disk, $this->path)) {
+                $failed[] = $disk;
+            }
 
             foreach ($directories as $directory) {
-                if (! empty($disk->allFiles($directory))) continue;
+                if (! empty($disk->allFiles($directory))) {
+                    continue;
+                }
 
                 $disk->deleteDirectory($directory);
             }


### PR DESCRIPTION
This PR adds a StorageCheck, it checks if the application is able to write to one or more configured disks.
It can be configured like this:
```php
OK::checks([
    StorageCheck::config()
        ->filename('test')
        ->disks(['local', 's3']),
]);
```
If filename is not set explicitly it will be defaulted to `laravel-ok::storage-check::file`.