### PR TITLE
add Redischeck

### DIFF
--- a/src/Checks/RedisCheck.php
+++ b/src/Checks/RedisCheck.php
@@ -15,8 +15,7 @@ class RedisCheck extends Check
     protected array $connections = [];
 
     /**
-     * @param non-empty-array<int, string>|string $connections
-     * @return static
+     * @param  non-empty-array<int, string>|string  $connections
      */
     public function withConnections($connections): static
     {

--- a/src/Checks/RedisCheck.php
+++ b/src/Checks/RedisCheck.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Vormkracht10\LaravelOK\Checks;
+
+use Illuminate\Support\Facades\Redis;
+use Vormkracht10\LaravelOK\Checks\Base\Check;
+use Vormkracht10\LaravelOK\Checks\Base\Result;
+
+class RedisCheck extends Check
+{
+    protected ?string $connection = null;
+
+    public function withConnection(string $connection): static
+    {
+        $this->connection = $connection;
+
+        return $this;
+    }
+
+    public function run(): Result
+    {
+        $result = Result::new();
+
+        try {
+            Redis::connection()->{'PING'}() !== 'PONG' ?? throw new \Exception;
+        } catch (\Exception) {
+            return $result->failed('Could not connect to Redis');
+        }
+
+        return $result->ok('Redis responded with PONG');
+    }
+}


### PR DESCRIPTION
This PR adds the RedisCheck, for each configured connection it checks if it can run the Redis `PING` command and fails if it can't connect to Redis.

It can be configured like this.
```php
OK::checks([
    RedisCheck::config()
        ->withConnections([
            'default',
            'cache',
        ]),
]);
```

If an empty array is passed to `RedisCheck#withConnections` the check will try to use the default connection.