### PR TITLE
add DatabaseConnectionCountCheck

### DIFF
--- a/src/Checks/DatabaseConnectionCountCheck.php
+++ b/src/Checks/DatabaseConnectionCountCheck.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Vormkracht10\LaravelOK\Checks;
+
+use Illuminate\Database\ConnectionResolverInterface;
+use Illuminate\Database\MySqlConnection;
+use Illuminate\Database\PostgresConnection;
+use Vormkracht10\LaravelOK\Checks\Base\Check;
+use Vormkracht10\LaravelOK\Checks\Base\Result;
+
+class DatabaseConnectionCountCheck extends Check
+{
+    protected ?string $connection = null;
+
+    protected int $maxConnections = 50;
+
+    public function withConnection(string $name): static
+    {
+        $this->connection = $name;
+
+        return $this;
+    }
+
+    public function setMaxConnections($value): static
+    {
+        $this->maxConnections = $value;
+
+        return $this;
+    }
+
+    public function run(): Result
+    {
+        $result = Result::new();
+
+        $connection = $this->connection ?? config('database.default');
+
+        if (($count = $this->getConnectionCount($connection)) > $this->maxConnections) {
+            return $result->failed("Too many database connections ({$count})");
+        }
+
+        return $result->ok("{$count} connections connected to the database");
+    }
+
+    protected function getConnectionCount(string $connectionName): int
+    {
+        $connection = app(ConnectionResolverInterface::class)->connection($connectionName);
+
+        return match (true) {
+            $connection instanceof MySqlConnection => (int) $connection->selectOne('show status where variable_name = "threads_connected"')->Value,
+            $connection instanceof PostgresConnection => (int) $connection->selectOne('select count(*) as connections from pg_stat_activity')->connections,
+            default => throw new \RuntimeException("Connection [{$connectionName}] not supported")
+        };
+    }
+}


### PR DESCRIPTION
This PR adds the DatabaseConnectionCountCheck. It can be configured like this
```php
OK::checks([
    DatabaseConnectionCountCheck::config()
        ->withConnection('mysql')
        ->setMaxConnections(5), // by default max connections is set to 50
]);
```