### PR TITLE
Feature/uptime check

### DIFF
--- a/src/Checks/UptimeCheck.php
+++ b/src/Checks/UptimeCheck.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Vormkracht10\LaravelOK\Checks;
+
+use Carbon\Carbon;
+use Illuminate\Support\Facades\Process;
+use RuntimeException;
+use Vormkracht10\LaravelOK\Checks\Base\Check;
+use Vormkracht10\LaravelOK\Checks\Base\Result;
+
+class UptimeCheck extends Check
+{
+    protected Carbon $maxTimeSinceRebootTimestamp;
+
+    public function setMaxTimeSinceRebootTimestamp(Carbon $time): static
+    {
+        $this->maxTimeSinceRebootTimestamp = $time;
+
+        return $this;
+    }
+
+    public function run(): Result
+    {
+        $result = Result::new();
+
+        $timestamp = $this->getSystemUptime();
+
+        if ($this->maxTimeSinceRebootTimestamp > $timestamp) {
+            return $result->failed("Last reboot was at [{$timestamp}], the maximum uptime for this server was set to [{$this->maxTimeSinceRebootTimestamp}]");
+        }
+
+        return $result->ok("Last reboot {$timestamp->diffInDays()} days and {$timestamp->diffInMinutes()} ago");
+    }
+
+    protected function getSystemUptime(): Carbon
+    {
+        return match (PHP_OS) {
+            "Linux" => $this->getSystemUptimeLinux(),
+            "Darwin" => $this->getSystemUptimeDarwin(),
+        };
+    }
+
+    protected function runProcess(string $command): string
+    {
+        $process = Process::run($command);
+
+        return match ($process->successful()) {
+            true => $process->output(),
+            false => throw new RuntimeException('Could not get system boot timestamp: ' . $process->errorOutput()),
+        };
+    }
+
+    protected function getSystemUptimeLinux(): Carbon
+    {
+        return Carbon::createFromTimestamp(
+            $this->runProcess('date -d "$(who -b | awk \'{print $3, $4}\')" +%s'),
+        );
+    }
+
+    protected function getSystemUptimeDarwin(): Carbon
+    {
+        return Carbon::createFromTimestamp(
+            $this->runProcess('date -j -f "%b %d %H:%M" "$(who -b | awk \'{print $3,$4,$5}\')" +%s'),
+        );
+    }
+}

--- a/src/Checks/UptimeCheck.php
+++ b/src/Checks/UptimeCheck.php
@@ -25,6 +25,10 @@ class UptimeCheck extends Check
 
         $timestamp = $this->getSystemUptime();
 
+        if (! isset($this->maxTimeSinceRebootTimestamp)) {
+            throw new \Exception('The max time since reboot was not set.');
+        }
+
         if ($this->maxTimeSinceRebootTimestamp > $timestamp) {
             return $result->failed("Last reboot was at [{$timestamp}], the maximum uptime for this server was set to [{$this->maxTimeSinceRebootTimestamp}]");
         }

--- a/src/Checks/UptimeCheck.php
+++ b/src/Checks/UptimeCheck.php
@@ -38,9 +38,10 @@ class UptimeCheck extends Check
 
     protected function getSystemUptime(): Carbon
     {
-        return match (PHP_OS) {
+        return match ($os = PHP_OS) {
             'Linux' => $this->getSystemUptimeLinux(),
             'Darwin' => $this->getSystemUptimeDarwin(),
+            default => throw new RuntimeException("This os ({$os}) is not supported by the UptimeCheck"),
         };
     }
 

--- a/src/Checks/UptimeCheck.php
+++ b/src/Checks/UptimeCheck.php
@@ -35,8 +35,8 @@ class UptimeCheck extends Check
     protected function getSystemUptime(): Carbon
     {
         return match (PHP_OS) {
-            "Linux" => $this->getSystemUptimeLinux(),
-            "Darwin" => $this->getSystemUptimeDarwin(),
+            'Linux' => $this->getSystemUptimeLinux(),
+            'Darwin' => $this->getSystemUptimeDarwin(),
         };
     }
 
@@ -46,7 +46,7 @@ class UptimeCheck extends Check
 
         return match ($process->successful()) {
             true => $process->output(),
-            false => throw new RuntimeException('Could not get system boot timestamp: ' . $process->errorOutput()),
+            false => throw new RuntimeException('Could not get system boot timestamp: '.$process->errorOutput()),
         };
     }
 


### PR DESCRIPTION
This PR adds the UptimeCheck. It can be configured like this
```php
OK::checks([
    UptimeCheck::config()
        ->setMaxTimeSinceRebootTimestamp(now()->subDays(7)), // This accepts a `Carbon`
]);
```
if `UptimeCheck#setMaxTimeSinceRebootTimestamp` has not been called the check will throw an exception upon running.
