### PR TITLE
add ProcessCountCheck

### DIFF
--- a/src/Checks/ProcessCountCheck.php
+++ b/src/Checks/ProcessCountCheck.php
@@ -31,8 +31,8 @@ class ProcessCountCheck extends Check
             }
         }
 
-        if (!empty($failed)) {
-            return $result->failed('Some commands have more processes running than should be allowed: [' . implode(', ', $failed) . ']');
+        if (! empty($failed)) {
+            return $result->failed('Some commands have more processes running than should be allowed: ['.implode(', ', $failed).']');
         }
 
         return $result->ok('All processes are ok');

--- a/src/Checks/ProcessCountCheck.php
+++ b/src/Checks/ProcessCountCheck.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Vormkracht10\LaravelOK\Checks;
+
+use Illuminate\Support\Facades\Process;
+use Vormkracht10\LaravelOK\Checks\Base\Check;
+use Vormkracht10\LaravelOK\Checks\Base\Result;
+
+class ProcessCountCheck extends Check
+{
+    protected array $processCountThresholds = [];
+
+    public function setProcessCountThresholds(array $config): static
+    {
+        $this->processCountThresholds = $this->processConfig($config);
+
+        return $this;
+    }
+
+    public function run(): Result
+    {
+        $result = Result::new();
+
+        $failed = [];
+
+        foreach ($this->processCountThresholds as $process => $config) {
+            $count = $this->getProcessCountForName($process, $config['exact'] ?? true);
+
+            if ($count > $config['max']) {
+                $failed[] = "{$process} ({$count})";
+            }
+        }
+
+        if (! empty($failed)) {
+            return $result->failed('Some commands have more processes running than should be allowed: ['.implode(', ', $failed).']');
+        }
+
+        return $result->ok('All processes are ok');
+    }
+
+    protected function processConfig(array $config): array
+    {
+        $reconstructed = [];
+
+        foreach ($config as $process => $processConfig) {
+            if (! is_array($processConfig) && ! is_int($processConfig)) {
+                throw new \Exception('The config for each process has to be either an integer (max process count) or an array');
+            }
+
+            if (is_int($processConfig)) {
+                $processConfig = ['max' => $processConfig];
+            }
+
+            if (! isset($processConfig['max']) || ! is_int($processConfig['max'])) {
+                throw new \Exception('The configured max process count has to be an integer');
+            }
+
+            $reconstructed[$process] = $processConfig;
+        }
+
+        return $reconstructed;
+    }
+
+    protected function getProcessCountForName(string $name, bool $exact = true): int
+    {
+        $command = $exact
+            ? "ps -e | awk '{print $4}' | sed 's:.*/::' | grep '^{$name}$'"
+            : "ps -e | awk '{print $4}' | sed 's:.*/::' | grep '{$name}'";
+
+        $process = Process::run($command);
+
+        if (! $process->successful()) {
+            return 0;
+        }
+
+        $output = $process->output();
+
+        return count(array_filter(explode("\n", $output)));
+    }
+}

--- a/src/Checks/ProcessCountCheck.php
+++ b/src/Checks/ProcessCountCheck.php
@@ -12,7 +12,7 @@ class ProcessCountCheck extends Check
 
     public function setProcessCountThresholds(array $config): static
     {
-        $this->processCountThresholds = $this->processConfig($config);
+        $this->processCountThresholds = $config;
 
         return $this;
     }
@@ -23,51 +23,24 @@ class ProcessCountCheck extends Check
 
         $failed = [];
 
-        foreach ($this->processCountThresholds as $process => $config) {
-            $count = $this->getProcessCountForName($process, $config['exact'] ?? true);
+        foreach ($this->processCountThresholds as $process => $max) {
+            $count = $this->getProcessCountForName($process);
 
-            if ($count > $config['max']) {
+            if ($count > $max) {
                 $failed[] = "{$process} ({$count})";
             }
         }
 
-        if (! empty($failed)) {
-            return $result->failed('Some commands have more processes running than should be allowed: ['.implode(', ', $failed).']');
+        if (!empty($failed)) {
+            return $result->failed('Some commands have more processes running than should be allowed: [' . implode(', ', $failed) . ']');
         }
 
         return $result->ok('All processes are ok');
     }
 
-    protected function processConfig(array $config): array
+    protected function getProcessCountForName(string $name): int
     {
-        $reconstructed = [];
-
-        foreach ($config as $process => $processConfig) {
-            if (! is_array($processConfig) && ! is_int($processConfig)) {
-                throw new \Exception('The config for each process has to be either an integer (max process count) or an array');
-            }
-
-            if (is_int($processConfig)) {
-                $processConfig = ['max' => $processConfig];
-            }
-
-            if (! isset($processConfig['max']) || ! is_int($processConfig['max'])) {
-                throw new \Exception('The configured max process count has to be an integer');
-            }
-
-            $reconstructed[$process] = $processConfig;
-        }
-
-        return $reconstructed;
-    }
-
-    protected function getProcessCountForName(string $name, bool $exact = true): int
-    {
-        $command = $exact
-            ? "ps -e | awk '{print $4}' | sed 's:.*/::' | grep '^{$name}$'"
-            : "ps -e | awk '{print $4}' | sed 's:.*/::' | grep '{$name}'";
-
-        $process = Process::run($command);
+        $process = Process::run("ps -e | awk '{print $4}' | sed 's:.*/::' | grep '^{$name}$'");
 
         if (! $process->successful()) {
             return 0;


### PR DESCRIPTION
This PR adds the ProcessCountCheck, it can be configured like this.
```php
OK::checks([
    ProcessCountCheck::config()
        ->setProcessCountThresholds([
            'php' => [
                'max' => 1,
                'exact' => false, // This will match phpstorm as well as the currently running php process.
                                  // Meaning the check will fail in this example. This would also match processes like-
                                  // php-8.1 and php-8.2.
            ],
            'phpstorm' => 1, // The 'exact' option is defaulted to `true`.
        ]),
]);
```