### PR TITLE
Feature/composer outdated check

### DIFF
--- a/src/Checks/CpuLoadCheck.php
+++ b/src/Checks/CpuLoadCheck.php
@@ -10,7 +10,7 @@ class CpuLoadCheck extends Check
 {
     protected array $maxLoad;
 
-    public function setMaxLoad(?float $short = null, ?float $mid = null, ?float $long = null): static
+    public function setMaxLoad(float $short = null, float $mid = null, float $long = null): static
     {
         $this->maxLoad = [$short, $mid, $long];
 
@@ -32,9 +32,13 @@ class CpuLoadCheck extends Check
         }
 
         foreach ($this->maxLoad as $index => $max) {
-            if (is_null($max)) continue;
+            if (is_null($max)) {
+                continue;
+            }
 
-            if ($index == count($load)) break;
+            if ($index == count($load)) {
+                break;
+            }
 
             if ($max < $actual = round($load[$index], 2)) {
                 return $result->failed(


### PR DESCRIPTION
This PR adds the CpuLoadCheck, it can be configured like this
```php
OK::checks([
    CpuLoadCheck::config()
        ->setMaxLoad(100, 95, 90),
]);
```
This check uses sys_getloadavg, this tries to get the system cpu load for the past 1, 5 and 15 minutes. It is configured in the same manner, the arguments correspond to 1 minute, 5 minute and 15 minute respectively.

You can also only configure for example the 15 minute long target
```php
CpuLoadCheck::config()
    ->setMaxLoad(long: 90),
```