### PR TITLE
add CpuLoadCheck

### DIFF
--- a/src/Checks/CpuLoadCheck.php
+++ b/src/Checks/CpuLoadCheck.php
@@ -11,9 +11,9 @@ class CpuLoadCheck extends Check
     protected array $maxLoad;
 
     public function setMaxLoad(
-        ?float $short = null,
-        ?float $mid = null,
-        ?float $long = null,
+        float $short = null,
+        float $mid = null,
+        float $long = null,
     ): static {
         $this->maxLoad = [$short, $mid, $long];
 
@@ -35,9 +35,13 @@ class CpuLoadCheck extends Check
         }
 
         foreach ($this->maxLoad as $index => $max) {
-            if (is_null($max)) continue;
+            if (is_null($max)) {
+                continue;
+            }
 
-            if ($index == count($load)) break;
+            if ($index == count($load)) {
+                break;
+            }
 
             if ($max < $actual = round($load[$index], 2)) {
                 return $result->failed(

--- a/src/Checks/CpuLoadCheck.php
+++ b/src/Checks/CpuLoadCheck.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Vormkracht10\LaravelOK\Checks;
+
+use Exception;
+use Vormkracht10\LaravelOK\Checks\Base\Check;
+use Vormkracht10\LaravelOK\Checks\Base\Result;
+
+class CpuLoadCheck extends Check
+{
+    protected array $maxLoad;
+
+    public function setMaxLoad(
+        ?float $short = null,
+        ?float $mid = null,
+        ?float $long = null,
+    ): static {
+        $this->maxLoad = [$short, $mid, $long];
+
+        return $this;
+    }
+
+    public function run(): Result
+    {
+        if (! isset($this->maxLoad)) {
+            throw new Exception('The max average load was not set');
+        }
+
+        $result = Result::new();
+
+        $load = sys_getloadavg();
+
+        if (! $load) {
+            return $result->failed('Failed to get system load averages');
+        }
+
+        foreach ($this->maxLoad as $index => $max) {
+            if (is_null($max)) continue;
+
+            if ($index == count($load)) break;
+
+            if ($max < $actual = round($load[$index], 2)) {
+                return $result->failed(
+                    "System average load [{$index}] is at {$max}%, max is configured at {$actual}%",
+                );
+            }
+        }
+
+        return $result->ok('System load averages are ok');
+    }
+}


### PR DESCRIPTION
This PR adds the CpuLoadCheck, it can be configured like this
```php
OK::checks([
    CpuLoadCheck::config()
        ->setMaxLoad(100, 95, 90),
]);
```
This check uses sys_getloadavg, this tries to get the system cpu load for the past 1, 5 and 15 minutes. It is configured in the same manner, the arguments correspond to 1 minute, 5 minute and 15 minute respectively.

You can also only configure for example the 15 minute long target
```php
CpuLoadCheck::config()
    ->setMaxLoad(long: 90),
```