### PR TITLE
add DatabaseTableSizeCheck

### DIFF
--- a/src/Checks/DatabaseTableSizeCheck.php
+++ b/src/Checks/DatabaseTableSizeCheck.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Vormkracht10\LaravelOK\Checks;
+
+use Illuminate\Database\Connection;
+use Illuminate\Database\ConnectionInterface;
+use Illuminate\Database\ConnectionResolverInterface;
+use Illuminate\Database\MySqlConnection;
+use Illuminate\Database\PostgresConnection;
+use Vormkracht10\LaravelOK\Checks\Base\Check;
+use Vormkracht10\LaravelOK\Checks\Base\Result;
+
+class DatabaseTableSizeCheck extends Check
+{
+    protected string $connectionName;
+
+    protected array $tableSizeThresholds = [];
+
+    public function onConnection(string $name): static
+    {
+        $this->connectionName = $name;
+
+        return $this;
+    }
+
+    public function setTableSizeThresholds(array $config): static
+    {
+        $this->tableSizeThresholds = $config;
+
+        return $this;
+    }
+
+    public function run(): Result
+    {
+        $result = Result::new();
+
+        $connectionName = $this->connectionName ?? config('database.default');
+
+        $connection = app(ConnectionResolverInterface::class)->connection($connectionName);
+
+        $config = array_map(
+            fn ($MB) => $MB * 1024 * 1024,
+            $this->tableSizeThresholds,
+        );
+
+        foreach ($config as $table => $max) {
+            $size = $this->getTableSize($connection, $table);
+
+            if ($size > $max) {
+                $mb = fn ($bytes) => round($bytes / 1024 / 1024, 2);
+
+                return $result->failed("Table [{$table}] size is {$mb($size)} megabytes, max is configured at {$mb($max)} megabytes");
+            }
+        }
+
+        return $result->ok();
+    }
+
+    protected function getTableSize(ConnectionInterface $connection, string $table): int
+    {
+        return match (true) {
+            $connection instanceof MySqlConnection => $connection->selectOne('SELECT (data_length + index_length) AS size FROM information_schema.TABLES WHERE table_schema = ? AND table_name = ?', [
+                $connection->getDatabaseName(),
+                $table,
+            ])->size,
+            $connection instanceof PostgresConnection => $connection->selectOne('SELECT pg_total_relation_size(?) AS size;', [
+                $table,
+            ])->size,
+            default => throw new \Exception("This database type is not supported"),
+        };
+    }
+}

--- a/src/Checks/DatabaseTableSizeCheck.php
+++ b/src/Checks/DatabaseTableSizeCheck.php
@@ -2,7 +2,6 @@
 
 namespace Vormkracht10\LaravelOK\Checks;
 
-use Illuminate\Database\Connection;
 use Illuminate\Database\ConnectionInterface;
 use Illuminate\Database\ConnectionResolverInterface;
 use Illuminate\Database\MySqlConnection;
@@ -66,7 +65,7 @@ class DatabaseTableSizeCheck extends Check
             $connection instanceof PostgresConnection => $connection->selectOne('SELECT pg_total_relation_size(?) AS size;', [
                 $table,
             ])->size,
-            default => throw new \Exception("This database type is not supported"),
+            default => throw new \Exception('This database type is not supported'),
         };
     }
 }

--- a/src/Checks/DatabaseTableSizeCheck.php
+++ b/src/Checks/DatabaseTableSizeCheck.php
@@ -22,7 +22,14 @@ class DatabaseTableSizeCheck extends Check
         return $this;
     }
 
-    public function setTableSizeThresholdsInMegabytes(array $config): static
+    public function setMaxTableSizeInGigabytes(array $config): static
+    {
+        return $this->setMaxTableSizeInMegabytes(
+            array_map(fn ($size) => $size * 1000, $config),
+        );
+    }
+
+    public function setMaxTableSizeInMegabytes(array $config): static
     {
         $this->tableSizeThresholds = $config;
 

--- a/src/Checks/DatabaseTableSizeCheck.php
+++ b/src/Checks/DatabaseTableSizeCheck.php
@@ -22,7 +22,7 @@ class DatabaseTableSizeCheck extends Check
         return $this;
     }
 
-    public function setTableSizeThresholds(array $config): static
+    public function setTableSizeThresholdsInMegabytes(array $config): static
     {
         $this->tableSizeThresholds = $config;
 


### PR DESCRIPTION
This PR adds the DatabaseTableSizeCheck, it can be configured like this.
```php
OK::checks([
    DatabaseTableSizeCheck::config()
        ->onConnection('mysql')
        ->setTableSizeThresholds([
            'users' => 50,// in megabytes
        ]),
]);
```