### PR TITLE
Feature/composer oudated check

### DIFF
--- a/src/Checks/ComposerOutdatedCheck.php
+++ b/src/Checks/ComposerOutdatedCheck.php
@@ -41,8 +41,6 @@ class ComposerOutdatedCheck extends Check
             fn ($package) => [$package => false],
         );
 
-        $packages->each(fn ($c) => print $c);
-
         $this->packages = $this->packages->merge($packages);
 
         return $this;

--- a/src/Checks/ComposerOutdatedCheck.php
+++ b/src/Checks/ComposerOutdatedCheck.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace Vormkracht10\LaravelOK\Checks;
+
+use Composer\Semver\Semver;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Process;
+use Vormkracht10\LaravelOK\Checks\Base\Check;
+use Vormkracht10\LaravelOK\Checks\Base\Result;
+
+class ComposerOutdatedCheck extends Check
+{
+    protected Collection $packages;
+
+    protected Collection $versions;
+
+    public function __construct()
+    {
+        $this->packages = new Collection;
+    }
+
+    /**
+     * @param array<string, array>|string[] $packages
+     * @return static
+     */
+    public function include(array $packages): static
+    {
+        $packages = collect($packages)->mapWithKeys(
+            fn ($package) => [$package => true],
+        );
+
+        $this->packages = $this->packages->merge($packages);
+
+        return $this;
+    }
+
+    /**
+     * @param array<int, string> $packages
+     * @return static
+     */
+    public function exclude(array $packages): static
+    {
+        $packages = collect($packages)->mapWithKeys(
+            fn ($package) => [$package => false],
+        );
+
+        $packages->each(fn ($c) => print $c);
+
+        $this->packages = $this->packages->merge($packages);
+
+        return $this;
+    }
+
+    public function checkVersionStatus(array $versions): static
+    {
+        $versions = collect($versions)->map(fn ($config) => [
+            'major' => $config['major'] ?? true,
+            'minor' => $config['minor'] ?? true,
+        ]);
+
+        $this->versions = $versions;
+
+        return $this;
+    }
+
+    public function run(): Result
+    {
+        $result = Result::new();
+
+        $outdated = $this->getOutdated();
+
+        if (! $outdated) {
+            return $result->failed('Failed to get outdated packages using composer');
+        }
+
+        $this->packages = (
+            ($included = $this->packages->filter(fn ($include) => $include))->isEmpty()
+                ? $outdated->mapWithKeys(fn ($versions, $name) => [$name => true])
+                : $included
+        )->merge($this->packages);
+
+        $failed = collect();
+
+        foreach ($this->packages as $package => $include) {
+            if (! $include || ! isset($outdated[$package])) continue;
+
+            if ($this->versions[$package][$outdated[$package]['status']] === false) continue;
+
+            $failed[$package] = $outdated[$package];
+        }
+
+        if (! $failed->isEmpty()) {
+            return $result->failed(<<<string
+            \nSome packages are not up-to-date:
+            \t{$failed->map(
+                fn ($versions, $package) => "{$package}: [current: {$versions['current']}] [latest: {$versions['latest']}]",
+            )->implode("\n\t")}
+            string);
+        }
+
+        return $result->ok('All packages are up-to-date');
+    }
+
+    protected function getOutdated(): Collection|false
+    {
+        $process = Process::run('composer outdated --format=json');
+
+        if (! $process->successful()) {
+            return false;
+        }
+
+        $data = json_decode(
+            $process->output(),
+            true,
+        );
+
+        return collect($data['installed'])
+            ->mapWithKeys(fn ($meta) => [$meta['name'] => [
+                'current' => $meta['version'],
+                'latest' => $meta['latest'],
+                'status' => match ($meta['latest-status']) {
+                    'semver-safe-update' => 'minor',
+                    'update-possible' => 'major',
+                    default => null,
+                },
+            ]]);
+    }
+}

--- a/src/Checks/ComposerOutdatedCheck.php
+++ b/src/Checks/ComposerOutdatedCheck.php
@@ -2,7 +2,6 @@
 
 namespace Vormkracht10\LaravelOK\Checks;
 
-use Composer\Semver\Semver;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Process;
 use Vormkracht10\LaravelOK\Checks\Base\Check;
@@ -20,8 +19,7 @@ class ComposerOutdatedCheck extends Check
     }
 
     /**
-     * @param array<string, array>|string[] $packages
-     * @return static
+     * @param  array<string, array>|string[]  $packages
      */
     public function include(array $packages): static
     {
@@ -35,8 +33,7 @@ class ComposerOutdatedCheck extends Check
     }
 
     /**
-     * @param array<int, string> $packages
-     * @return static
+     * @param  array<int, string>  $packages
      */
     public function exclude(array $packages): static
     {
@@ -82,9 +79,13 @@ class ComposerOutdatedCheck extends Check
         $failed = collect();
 
         foreach ($this->packages as $package => $include) {
-            if (! $include || ! isset($outdated[$package])) continue;
+            if (! $include || ! isset($outdated[$package])) {
+                continue;
+            }
 
-            if ($this->versions[$package][$outdated[$package]['status']] === false) continue;
+            if ($this->versions[$package][$outdated[$package]['status']] === false) {
+                continue;
+            }
 
             $failed[$package] = $outdated[$package];
         }

--- a/src/Checks/ComposerOutdatedCheck.php
+++ b/src/Checks/ComposerOutdatedCheck.php
@@ -2,7 +2,6 @@
 
 namespace Vormkracht10\LaravelOK\Checks;
 
-use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Process;
 use Vormkracht10\LaravelOK\Checks\Base\Check;
@@ -37,7 +36,7 @@ class ComposerOutdatedCheck extends Check
     }
 
     /**
-     * @param array<string, SemverLevel> $versions
+     * @param  array<string, SemverLevel>  $versions
      */
     public function versions(array $versions): static
     {

--- a/src/Enums/SemverLevel.php
+++ b/src/Enums/SemverLevel.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Vormkracht10\LaravelOK\Enums;
+
+enum SemverLevel: string
+{
+    case All = 'all';
+    case Major = 'major';
+    case Minor = 'minor';
+}


### PR DESCRIPTION
This PR adds the ComposerOutdatedCheck, it can be configured like this
```php
ComposerOutdatedCheck::config()
    ->exclude(['orchestra/workbench'])
    ->include(['laravel/framework'])
    ->checkVersionStatus([
        'laravel/framework' => [
            'major' => true, // will be defaulted to `true` if missing
            'minor' => true, // will be defaulted to `true` if missing
        ],
    ]);
```
By default the version gets checked for both major and minor version upgrades.

If there is no "included" packages configured, this check will presume *all* packages should be checked (with exception for the excluded packages of course.)