### PR TITLE
add timeout for notifications on a per check basis.

### DIFF
--- a/config/ok.php
+++ b/config/ok.php
@@ -11,6 +11,8 @@ return [
 
         'notifiable' => Notifiable::class,
 
+        'interval' => now()->subMinutes(15),
+
         'via' => [
             // 'discord' => [
             //     'channel' => 123456790,

--- a/config/ok.php
+++ b/config/ok.php
@@ -5,13 +5,15 @@ use Vormkracht10\LaravelOK\Notifications\Notifiable;
 
 return [
     'notifications' => [
-        'enabled' => env('LARAVEL_OK_NOTIFICATIONS_ENABLED', true),
+        'enabled' => env('OK_NOTIFICATIONS_ENABLED', true),
 
         'failed_notification' => CheckFailedNotification::class,
 
         'notifiable' => Notifiable::class,
 
-        'interval' => now()->subMinutes(15),
+        'interval_in_minutes' => env('OK_NOTIFICATION_INTERVAL', 60 * 60 * 24),
+
+        'cache_driver' => env('OK_CACHE_DRIVER', 'file'),
 
         'via' => [
             // 'discord' => [

--- a/src/Checks/Base/Check.php
+++ b/src/Checks/Base/Check.php
@@ -2,6 +2,7 @@
 
 namespace Vormkracht10\LaravelOK\Checks\Base;
 
+use Carbon\Carbon;
 use Cron\CronExpression;
 use Illuminate\Console\Scheduling\ManagesFrequencies;
 use Illuminate\Support\Facades\Date;
@@ -24,6 +25,10 @@ abstract class Check
 
     protected string $expression = '* * * * *';
 
+    protected int $repeatSeconds;
+
+    protected Carbon $reportTimeout;
+
     protected ?string $name = null;
 
     protected ?string $message = null;
@@ -34,10 +39,6 @@ abstract class Check
 
     protected int $timesToFailWithoutNotification = 1;
 
-    public function __construct()
-    {
-    }
-
     public static function config(): static
     {
         $instance = app(static::class);
@@ -45,6 +46,16 @@ abstract class Check
         $instance->everyMinute();
 
         return $instance;
+    }
+
+    public function getExpression(): string
+    {
+        return $this->expression;
+    }
+
+    public function getRepeatSeconds(): int
+    {
+        return $this->repeatSeconds;
     }
 
     public function name(string $name): self
@@ -107,5 +118,17 @@ abstract class Check
     public function markAsCrashed(): Result
     {
         return new Result(Status::CRASHED);
+    }
+
+    public function getReportTimeout(): Carbon
+    {
+        return $this->reportTimeout;
+    }
+
+    public function reportTimeout(Carbon $minimumDelay): static
+    {
+        $this->reportTimeout = $minimumDelay;
+
+        return $this;
     }
 }

--- a/src/Checks/Base/Check.php
+++ b/src/Checks/Base/Check.php
@@ -125,7 +125,7 @@ abstract class Check
         return $this->reportInterval ?? config('ok.notifications.interval', Carbon::now()->subMinutes(30));
     }
 
-    public function reportInterval(Carbon $minimumDelay): static
+    public function setNotificationInterval(Carbon $minimumDelay): static
     {
         $this->reportInterval = $minimumDelay;
 

--- a/src/Checks/Base/Check.php
+++ b/src/Checks/Base/Check.php
@@ -2,7 +2,6 @@
 
 namespace Vormkracht10\LaravelOK\Checks\Base;
 
-use Carbon\Carbon;
 use Cron\CronExpression;
 use Illuminate\Console\Scheduling\ManagesFrequencies;
 use Illuminate\Support\Facades\Date;
@@ -27,7 +26,7 @@ abstract class Check
 
     protected int $repeatSeconds;
 
-    protected Carbon $reportInterval;
+    protected int $notificationIntervalInMinutes;
 
     protected ?string $name = null;
 
@@ -120,14 +119,14 @@ abstract class Check
         return new Result(Status::CRASHED);
     }
 
-    public function getReportInterval(): Carbon
+    public function getNotificationInterval(): int
     {
-        return $this->reportInterval ?? config('ok.notifications.interval', Carbon::now()->subMinutes(30));
+        return $this->notificationIntervalInMinutes ?? config('ok.notifications.interval_in_minutes');
     }
 
-    public function setNotificationInterval(Carbon $minimumDelay): static
+    public function setNotificationInterval(int $intervalInMinutes): static
     {
-        $this->reportInterval = $minimumDelay;
+        $this->notificationIntervalInMinutes = $intervalInMinutes;
 
         return $this;
     }

--- a/src/Checks/Base/Check.php
+++ b/src/Checks/Base/Check.php
@@ -27,7 +27,7 @@ abstract class Check
 
     protected int $repeatSeconds;
 
-    protected Carbon $reportTimeout;
+    protected Carbon $reportInterval;
 
     protected ?string $name = null;
 
@@ -120,14 +120,14 @@ abstract class Check
         return new Result(Status::CRASHED);
     }
 
-    public function getReportTimeout(): Carbon
+    public function getReportInterval(): Carbon
     {
-        return $this->reportTimeout;
+        return $this->reportInterval ?? config('ok.notifications.interval', Carbon::now()->subMinutes(30));
     }
 
-    public function reportTimeout(Carbon $minimumDelay): static
+    public function reportInterval(Carbon $minimumDelay): static
     {
-        $this->reportTimeout = $minimumDelay;
+        $this->reportInterval = $minimumDelay;
 
         return $this;
     }

--- a/src/Checks/PermissionCheck.php
+++ b/src/Checks/PermissionCheck.php
@@ -12,8 +12,6 @@ class PermissionCheck extends Check
 
     public function __construct(array $configured = [])
     {
-        parent::__construct();
-
         $this->configured = $configured;
     }
 

--- a/src/Commands/RunChecksCommand.php
+++ b/src/Commands/RunChecksCommand.php
@@ -36,9 +36,7 @@ class RunChecksCommand extends Command
     {
         return app(OK::class)
             ->configuredChecks()
-            ->map(function (mixed $check) {
-                return is_string($check) ? app($check) : $check;
-            })
+            ->map(fn ($check) => is_string($check) ? app($check) : $check)
             ->map(function (Check $check): Result {
                 return $check->shouldRun()
                     ? $this->runCheck($check)

--- a/src/Listeners/SendCheckFailedNotification.php
+++ b/src/Listeners/SendCheckFailedNotification.php
@@ -2,10 +2,10 @@
 
 namespace Vormkracht10\LaravelOK\Listeners;
 
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Cache;
 use Vormkracht10\LaravelOK\Checks\Base\Check;
 use Vormkracht10\LaravelOK\Events\CheckFailed;
-use Vormkracht10\LaravelOK\Facades\OK;
 
 class SendCheckFailedNotification
 {
@@ -25,20 +25,37 @@ class SendCheckFailedNotification
 
         $notifiable->notify($notification);
 
-        $class = $event->check::class;
+        $this->setNotificationTimestamp($check);
+    }
 
-        Cache::driver('file')->set(
-            "laravel-ok::runs::{$class}",
+    protected function setNotificationTime(Check $check): int
+    {
+        return Cache::driver('file')->forever(
+            'laravel-ok::notifications::'.$check::class,
             now()->getTimestamp(),
         );
     }
 
+    protected function getLastNotifiedTime(Check $check): ?Carbon
+    {
+        $timestamp = Cache::driver('file')
+            ->get('laravel-ok::notifications::'.$check::class);
+
+        if (! $timestamp) {
+            return null;
+        }
+
+        return Carbon::createFromTimestamp($timestamp);
+    }
+
     protected function shouldSendNotification(Check $check): bool
     {
-        $lastRun = OK::lastRun($check::class);
+        $lastNotified = $this->getLastNotifiedTime($check);
 
-        $interval = $check->getReportInterval();
+        if (! $lastNotified) {
+            return true;
+        }
 
-        return $lastRun < $interval;
+        return now() >= $lastNotified->addMinutes($check->getNotificationInterval());
     }
 }

--- a/src/Listeners/SendCheckFailedNotification.php
+++ b/src/Listeners/SendCheckFailedNotification.php
@@ -21,7 +21,7 @@ class SendCheckFailedNotification
 
         $failedNotificationClass = config('ok.notifications.failed_notification');
 
-        $notification = (new $failedNotificationClass($event->check, $event->result));
+        $notification = new $failedNotificationClass($event->check, $event->result);
 
         $notifiable->notify($notification);
 
@@ -37,8 +37,8 @@ class SendCheckFailedNotification
     {
         $lastRun = OK::lastRun($check::class);
 
-        $timeout = $check->getReportTimeout();
+        $interval = $check->getReportInterval();
 
-        return $lastRun < $timeout;
+        return $lastRun < $interval;
     }
 }

--- a/src/OK.php
+++ b/src/OK.php
@@ -2,6 +2,9 @@
 
 namespace Vormkracht10\LaravelOK;
 
+use Carbon\Carbon;
+use Illuminate\Support\Facades\Cache;
+
 class OK
 {
     protected array $checks = [];
@@ -11,6 +14,13 @@ class OK
         $this->checks = array_merge($this->checks, $checks);
 
         return $this;
+    }
+
+    public function lastRun(string $check): Carbon
+    {
+        $timestamp = Cache::driver('file')->get("laravel-ok::runs::{$check}");
+
+        return Carbon::createFromTimestamp($timestamp);
     }
 
     public function configuredChecks()

--- a/src/OK.php
+++ b/src/OK.php
@@ -2,9 +2,6 @@
 
 namespace Vormkracht10\LaravelOK;
 
-use Carbon\Carbon;
-use Illuminate\Support\Facades\Cache;
-
 class OK
 {
     protected array $checks = [];
@@ -14,13 +11,6 @@ class OK
         $this->checks = array_merge($this->checks, $checks);
 
         return $this;
-    }
-
-    public function lastRun(string $check): Carbon
-    {
-        $timestamp = Cache::driver('file')->get("laravel-ok::runs::{$check}");
-
-        return Carbon::createFromTimestamp($timestamp);
     }
 
     public function configuredChecks()


### PR DESCRIPTION
Je kan nu `Check::reportTimeout` chainen op je check definition om een notification timeout in te stellen.
```php
OK::checks([
    DatabaseTableSizeCheck::config()
        ->setNotificationInterval(now()->subHour()) // een notification kan maar eens in het uur worden verstuurd
        ->setMaxTableSizeInGigabytes([
            'content' => 0.001,
        ]),
]);
```